### PR TITLE
feat(neovim): initial version of nvim plugin

### DIFF
--- a/neovim/lua/pest-tools/init.lua
+++ b/neovim/lua/pest-tools/init.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+---Setup pest.nvim
+function M.setup(config)
+    vim.filetype.add({
+        extension = {
+            pest = 'pest'
+        },
+    })
+end
+
+return M

--- a/neovim/syntax/pest.vim
+++ b/neovim/syntax/pest.vim
@@ -1,0 +1,40 @@
+" Vim syntax file
+" Language: Pest grammar specification
+" Maintainer: Samyak Sarnayak <samyak201@gmail.com>
+" Last Change: 2023-05-31
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let b:current_syntax = "pest"
+
+setlocal foldmethod=syntax
+
+" Keywords
+syn keyword pestKeywords ANY SOI EOI PUSH PEEK POP DROP
+
+" regions
+syn region pestProductionRHS matchgroup=pestBraces start="{" end="}" fold transparent
+syn region pestString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline
+syn region pestChar start=/'/ skip=/\\'/ end=/'/ oneline
+
+" stuff
+syn match pestIdent "[[:alnum:]_]\+" display
+
+syn match pestPunctuation '\~\|='
+
+syn match pestSpecial display "@\|^\|?\|*\|!\|&\|#"
+
+syn match pestComment "//.*$" contains=pestTodo
+syn keyword pestTodo contained TODO FIXME XXX NB NOTE
+
+highlight default link pestKeywords Keyword
+highlight default link pestIdent Identifier
+highlight default link pestPunctuation Delimiter
+highlight default link pestBraces Delimiter
+highlight default link pestSpecial Special
+highlight default link pestComment Comment
+highlight default link pestTodo Todo
+highlight default link pestString String
+highlight default link pestChar Character


### PR DESCRIPTION
A part of #10

# Summary

<img width="740" alt="image" src="https://github.com/pest-parser/pest-ide-tools/assets/34161949/99980fc0-96df-41fc-bb26-092660a90d9d">

An attempt at a neovim plugin for pest that provides:
- [x] filetype recognition
- [x] basic syntax highlighting
- [ ] LSP support

TODO:
- [ ] README
- [ ] Installation options (may require moving this plugin to a separate repo)

# Syntax highlighting

This plugin provides a basic syntax highlight using vim's built-in highlighter (which is a basic lexical highlighter). This seems to work well enough (see bugs below). Though, a treesitter grammar (#26) would work much better with neovim and will help other editors too.

Bugs:
- [ ] For identifiers, the first character of the line doesn't seem to get highlighted correctly. I tried debugging for hours, no dice.

# LSP support

This is already implemented in https://github.com/neovim/nvim-lspconfig/pull/2629, https://github.com/mason-org/mason-registry/pull/1641, https://github.com/williamboman/mason-lspconfig.nvim/pull/230. If you use `mason.nvim`, you can simply do (even without this new plugin):
```
set filetype=pest
LspInstall pest_ls
```

Since this plugin adds filetype recognition, you can skip the first step once you install this plugin.

Another feature this plugin could add is to provide a `setup` function that sets up the LSP with any special config that is needed.