### PR TITLE
Add quotes around ${path} when invoking the LS

### DIFF
--- a/vscode/client/src/server.ts
+++ b/vscode/client/src/server.ts
@@ -24,7 +24,8 @@ export async function findServer(): Promise<string | undefined> {
 	const config = workspace.getConfiguration("pestIdeTools");
 	const updateCheckerEnabled = config.get("checkForUpdates") as boolean;
 
-	const currentVersion = await promisify(exec)(`${path} --version`).then(s =>
+	// use quotes around path because the path may have spaces in it
+	const currentVersion = await promisify(exec)(`"${path}" --version`).then(s =>
 		s.stdout.trim()
 	);
 	outputChannel.appendLine(`[TS] Server version: v${currentVersion}`);

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pest-ide-tools",
-	"version": "0.3.3",
+	"version": "0.3.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pest-ide-tools",
-			"version": "0.3.3",
+			"version": "0.3.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"node-fetch": "^3.3.2",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -106,8 +106,8 @@
 		"publish:ovsx": "ovsx publish -p $OPENVSX_PAT",
 		"fix": "gts fix",
 		"lint": "gts lint -- . --max-warnings 0",
-		"fmt": "prettier --write 'client/**/*.ts' '*.js' 'language-configuration.json' 'tsconfig.json' 'syntaxes/*.json'",
-		"fmt-check": "prettier --check 'client/**/*.ts' '*.js' 'language-configuration.json' 'tsconfig.json' 'syntaxes/*.json'",
+		"fmt": "prettier --write \"client/**/*.ts\" \"*.js\" \"language-configuration.json\" \"tsconfig.json\" \"syntaxes/*.json\"",
+		"fmt-check": "prettier --check \"client/**/*.ts\" \"*.js\" \"language-configuration.json\" \"tsconfig.json\" \"syntaxes/*.json\"",
 		"esbuild-with-rust": "cd .. && cargo build -p pest-language-server && cd vscode && npm run esbuild-client",
 		"esbuild-client": "esbuild client=./client/src --bundle --outdir=build --external:vscode --format=cjs --platform=node --minify",
 		"vscode:prepublish": "npm run esbuild-client"


### PR DESCRIPTION
Add quotes around ${path} when invoking the language server

### Why?
If the path has spaces then the command will fail if it's not in quotes on Windows. I'm not sure if this is true for Mac or Linux as well