### PR TITLE
Don't emit unused rule warning if rule name begins with underscore

### DIFF
--- a/language-server/src/analysis.rs
+++ b/language-server/src/analysis.rs
@@ -119,7 +119,7 @@ impl Analysis {
                     false
                 }
             })
-            .filter(|(name, _)| !BUILTINS.contains(&name.as_str()))
+            .filter(|(name, _)| !BUILTINS.contains(&name.as_str()) && !name.starts_with('_'))
             .map(|(name, ra)| {
                 (
                     name,


### PR DESCRIPTION
Following rust's lead, it seems reasonable to stifle the 'unused' warning when the name starts with `_`.

My motivation for this change is that I like to define rules for testing a portion of a grammar, particularly while first writing the grammar.

For example,
```
stmt   =  { ... }
_stmts = _{ (stmt ~ NEWLINE+)* }

function   =  { ... }
_functions = { ... }
```

Then I define some rust tests that parse files using these rules.
```rust
#[dir_test(
    dir: "$CARGO_MANIFEST_DIR/test_files/syntax/stmts",
    glob: "*.sntn"
)]
fn test_stmts(fixture: Fixture<&str>) {
    test_rule(Rule::_stmts, fixture)
}

#[dir_test(
    dir: "$CARGO_MANIFEST_DIR/test_files/syntax/func",
    glob: "*.sntn"
)]
fn test_func(fixture: Fixture<&str>) {
    test_rule(Rule::_functions, fixture)
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering logic to exclude names starting with an underscore, in addition to built-in names. This ensures a cleaner and more accurate analysis output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->