### PR TITLE
fix(vscode): parse version number correctly from --version output

### DIFF
--- a/language-server/Cargo.toml
+++ b/language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pest-language-server"
-version = "0.3.12"
+version = "0.3.13"
 authors = ["Jamalam <james@jamalam.tech>"]
 description = "A language server for Pest."
 edition = "2024"

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes will be documented in this file.
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## v0.3.13
+
+- fix(vscode): parse version number correctly from `--version` output using `awk`
+
 ## v0.3.11
 
 - fix(ci): update Node version for OpenVSX publishing.

--- a/vscode/client/src/server.ts
+++ b/vscode/client/src/server.ts
@@ -19,9 +19,9 @@ export async function findServer(): Promise<string | undefined> {
 	const updateCheckerEnabled = config.get("checkForUpdates") as boolean;
 
 	// use quotes around path because the path may have spaces in it
-	const currentVersion = await promisify(exec)(`"${path}" --version`).then(s =>
-		s.stdout.trim(),
-	);
+	const currentVersion = await promisify(exec)(
+		`"${path}" --version | awk '{print $2}'`,
+	).then(s => s.stdout.trim());
 	outputChannel.appendLine(`[TS] Server version: v${currentVersion}`);
 
 	if (updateCheckerEnabled && config.get("serverPath") === null) {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -15,7 +15,7 @@
     "Formatters",
     "Programming Languages"
   ],
-  "version": "0.3.12",
+  "version": "0.3.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/pest-parser/pest-ide-tools"


### PR DESCRIPTION
Use awk to extract just the version number from the server's --version output, and bump extension version to 0.3.13.

<img width="497" height="174" alt="image" src="https://github.com/user-attachments/assets/7d1a6106-d5fc-4b9f-88cc-f535e2bcd938" />


Fixes https://github.com/pest-parser/pest-ide-tools/issues/164

---

_Note_: The proposed fix in the issue (which was since closed) was to remove the feature altogether. Since the fix is particularly easy I prepared a PR just in case.

_Note2_: It is proposing a downgrade because the logic doesn't check if the upstream is newer, just if it is different. But as you can see from the picture, the version is formatted correctly. I have also verified that with the old binary I get no notification.