### PR TITLE
fix(vscode): parse version number without awk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes will be documented in this file.
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 <!-- Only update the CHANGELOG.md file in the root of the repository - symlink should keep vscode/CHANGELOG.md identical. -->
+## v0.3.14
+
+- fix(vscode): parse version number from `--version` output without `awk`
+
 ## v0.3.13
 
 - fix(vscode): parse version number correctly from `--version` output using `awk`

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes will be documented in this file.
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 <!-- Only update the CHANGELOG.md file in the root of the repository - symlink should keep vscode/CHANGELOG.md identical. -->
+## v0.3.14
+
+- fix(vscode): parse version number from `--version` output without `awk`
+
 ## v0.3.13
 
 - fix(vscode): parse version number correctly from `--version` output using `awk`

--- a/vscode/client/src/server.ts
+++ b/vscode/client/src/server.ts
@@ -19,9 +19,9 @@ export async function findServer(): Promise<string | undefined> {
 	const updateCheckerEnabled = config.get("checkForUpdates") as boolean;
 
 	// use quotes around path because the path may have spaces in it
-	const currentVersion = await promisify(exec)(
-		`"${path}" --version | awk '{print $2}'`,
-	).then(s => s.stdout.trim());
+	const currentVersion = await promisify(exec)(`"${path}" --version`).then(
+		s => s.stdout.trim().split(/\s+/)[1],
+	);
 	outputChannel.appendLine(`[TS] Server version: v${currentVersion}`);
 
 	if (updateCheckerEnabled && config.get("serverPath") === null) {

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pest-ide-tools",
-  "version": "0.3.12",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pest-ide-tools",
-      "version": "0.3.12",
+      "version": "0.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -15,7 +15,7 @@
     "Formatters",
     "Programming Languages"
   ],
-  "version": "0.3.13",
+  "version": "0.3.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/pest-parser/pest-ide-tools"


### PR DESCRIPTION
Replace the shell pipeline using awk with a JavaScript-side split, removing the dependency on awk which may not be available on all platforms. Bump version to 0.3.14.

<img width="906" height="71" alt="image" src="https://github.com/user-attachments/assets/27d3bea9-2daa-444c-965d-3109a7eeca12" />
