### PR TITLE
fix: improve Windows compatibility for language server discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes will be documented in this file.
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 <!-- Only update the CHANGELOG.md file in the root of the repository - symlink should keep vscode/CHANGELOG.md identical. -->
+
+## v0.3.14
+
+- fix(vscode): replace `awk` with pure JavaScript for version parsing (Windows compatibility)
+- fix(vscode): auto-append `.exe` suffix on Windows for custom server paths
+
 ## v0.3.13
 
 - fix(vscode): parse version number correctly from `--version` output using `awk`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "pest-language-server"
-version = "0.3.12"
+version = "0.3.14"
 dependencies = [
  "clap",
  "pest",

--- a/language-server/Cargo.toml
+++ b/language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pest-language-server"
-version = "0.3.13"
+version = "0.3.14"
 authors = ["Jamalam <james@jamalam.tech>"]
 description = "A language server for Pest."
 edition = "2024"

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes will be documented in this file.
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 <!-- Only update the CHANGELOG.md file in the root of the repository - symlink should keep vscode/CHANGELOG.md identical. -->
+
+## v0.3.14
+
+- fix(vscode): replace `awk` with pure JavaScript for version parsing (Windows compatibility)
+- fix(vscode): auto-append `.exe` suffix on Windows for custom server paths
+
 ## v0.3.13
 
 - fix(vscode): parse version number correctly from `--version` output using `awk`

--- a/vscode/client/src/server.ts
+++ b/vscode/client/src/server.ts
@@ -19,9 +19,8 @@ export async function findServer(): Promise<string | undefined> {
 	const updateCheckerEnabled = config.get("checkForUpdates") as boolean;
 
 	// use quotes around path because the path may have spaces in it
-	const currentVersion = await promisify(exec)(
-		`"${path}" --version | awk '{print $2}'`,
-	).then(s => s.stdout.trim());
+	const { stdout } = await promisify(exec)(`"${path}" --version`);
+	const currentVersion = stdout.trim().split(/\s+/)[1] ?? "unknown";
 	outputChannel.appendLine(`[TS] Server version: v${currentVersion}`);
 
 	if (updateCheckerEnabled && config.get("serverPath") === null) {
@@ -81,16 +80,21 @@ async function findServerPath(): Promise<string | undefined> {
 
 	// Check for custom server path
 	if (config.get("serverPath") && workspace.workspaceFolders !== undefined) {
-		outputChannel.appendLine(
-			path.resolve(
-				workspace.workspaceFolders[0].uri.fsPath,
-				config.get("serverPath") as string,
-			),
-		);
-		return path.resolve(
+		const resolvedPath = path.resolve(
 			workspace.workspaceFolders[0].uri.fsPath,
 			config.get("serverPath") as string,
 		);
+		outputChannel.appendLine(resolvedPath);
+
+		// On Windows, try adding .exe suffix if the path doesn't exist
+		if (process.platform === "win32" && !(await checkValidity(resolvedPath))) {
+			const exePath = resolvedPath + ".exe";
+			if (await checkValidity(exePath)) {
+				return exePath;
+			}
+		}
+
+		return resolvedPath;
 	}
 
 	const cargoBinDirectory = getCargoBinDirectory();

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pest-ide-tools",
-  "version": "0.3.12",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pest-ide-tools",
-      "version": "0.3.12",
+      "version": "0.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -15,7 +15,7 @@
     "Formatters",
     "Programming Languages"
   ],
-  "version": "0.3.13",
+  "version": "0.3.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/pest-parser/pest-ide-tools"


### PR DESCRIPTION
## Summary

This PR fixes two Windows compatibility issues in the VS Code extension's language server discovery mechanism.

## Changes

### 1. Replace `awk` with pure JavaScript version parsing

**Problem:** The original code used `awk '{print $2}'` to extract the version number from the language server's `--version` output. This command is not available on Windows, causing the extension activation to fail with:
`
Command failed: "path\to\pest-language-server.exe" --version | awk '{print $2}'
'awk' is not recognized as an internal or external command
`

**Solution:** Use JavaScript's `String.prototype.split()` with a regex to parse the version:

```typescript
// Before
const currentVersion = await promisify(exec)(
    `"${path}" --version | awk '{print $2}'`,
).then(s => s.stdout.trim());

// After
const { stdout } = await promisify(exec)(`"${path}" --version`);
const currentVersion = stdout.trim().split(/\s+/)[1] ?? "unknown";
```

### 2. Auto-append `.exe` suffix on Windows for custom server paths

**Problem:** When users configure a custom `pestIdeTools.serverPath` on Windows without the `.exe` suffix, the extension fails to find the binary.

**Solution:** Automatically try appending `.exe` on Windows if the original path doesn't exist:

```typescript
if (process.platform === "win32" && !(await checkValidity(resolvedPath))) {
    const exePath = resolvedPath + ".exe";
    if (await checkValidity(exePath)) {
        return exePath;
    }
}
```

This allows users to use a cross-platform configuration like:

```json
{
  "pestIdeTools.serverPath": "../../target/debug/pest-language-server"
}
```

## Testing

- [x] Tested on Windows 11
- [x] Extension activates successfully
- [x] Language server starts correctly
- [x] Version detection works

## Related Issues
Fixes #221

---

*This PR was created with AI assistance for code analysis and documentation.*